### PR TITLE
Improved List Injection

### DIFF
--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/InjectionRegistrationController.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/InjectionRegistrationController.cs
@@ -7,117 +7,139 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Core;
 
 namespace CapeCode.DependencyInjection.Core {
-	public class InjectionRegistrationController {
+    public class InjectionRegistrationController {
 
-		public InjectionRegistrationController( IList<object> enumRestrictions ) {
-			_enumRestrictions = enumRestrictions;
-		}
+        public InjectionRegistrationController( IList<object> enumRestrictions ) {
+            _enumRestrictions = enumRestrictions;
+        }
 
-		private readonly IList<object> _enumRestrictions;
+        private readonly IList<object> _enumRestrictions;
 
-		public void RegisterAllClasses( IServiceCollection serviceCollection, Assembly assembly ) {
-			IList<Type> types;
-			try {
-				types = assembly.GetTypes();
-			} catch ( ReflectionTypeLoadException ex ) {
-				throw new Exception( $@"Loading the types {( ex.Types != null ? string.Join( ", ", ex.Types.Where( t => t != null ).Select( t => t.FullName ) ) : "'NULL'" )} failed with: \n {( ex.LoaderExceptions != null ? string.Join( @"\n\n", ex.LoaderExceptions.Where( e => e != null ).Select( e => e.ToString() ) ) : "'NULL'" )}", ex );
-			}
+        private ListInjectionRegistrationManager _listInjectionRegistrationManager = new ListInjectionRegistrationManager();
 
-			foreach ( Type type in types ) {
-				RegisterType( serviceCollection, type );
-			}
-		}
+        public void RegisterAllClasses( IServiceCollection serviceCollection, Assembly assembly ) {
+            IList<Type> types;
+            try {
+                types = assembly.GetTypes();
+            } catch ( ReflectionTypeLoadException ex ) {
+                throw new Exception( $@"Loading the types {( ex.Types != null ? string.Join( ", ", ex.Types.Where( t => t != null ).Select( t => t.FullName ) ) : "'NULL'" )} failed with: \n {( ex.LoaderExceptions != null ? string.Join( @"\n\n", ex.LoaderExceptions.Where( e => e != null ).Select( e => e.ToString() ) ) : "'NULL'" )}", ex );
+            }
 
-		public void RegisterType( IServiceCollection serviceCollection, Type type ) {
-			if ( !type.IsInterface ) {
-				if ( type.IsClass && !type.IsAbstract ) {
-					// Filter attributes to have only attributes for arbitrary environments and attributes fitting to the current environment.
-					var isEnvironmentCorrect = type.EvaluateDerivedCustomAttributePredicate<InjectionEnumRestrictionAttribute>( era => era.ValidEnumValues.Any( vev => _enumRestrictions.Any( ev => Equals( ev, vev ) ) ), trueIfEmpty: true );
+            foreach ( Type type in types ) {
+                RegisterType( serviceCollection, type );
+            }
+        }
 
-					var registrationAttributes = type.GetSingleCustomDerivedAttribute<InjectionRegistrationAttribute>();
+        public void RegisterType( IServiceCollection serviceCollection, Type type ) {
+            if ( !type.IsInterface ) {
+                if ( type.IsClass && !type.IsAbstract ) {
+                    // Filter attributes to have only attributes for arbitrary environments and attributes fitting to the current environment.
+                    var isEnvironmentCorrect = type.EvaluateDerivedCustomAttributePredicate<InjectionEnumRestrictionAttribute>( era => era.ValidEnumValues.Any( vev => _enumRestrictions.Any( ev => Equals( ev, vev ) ) ), trueIfEmpty: true );
 
-					if ( registrationAttributes.Any() && isEnvironmentCorrect ) {
-						var injectInListAttributes = type.GetSingleCustomAttribute<InjectInListAttribute>();
+                    var registrationAttributes = type.GetSingleCustomDerivedAttribute<InjectionRegistrationAttribute>();
 
-						var registrationAttribute = registrationAttributes.First();
-						Type[] interfaceTypes;
-						if ( registrationAttribute.RegisteredInterfaces.Length > 0 ) {
-							if ( !registrationAttribute.RegisteredInterfaces.Contains( type ) ) {
-								interfaceTypes = new Type[ registrationAttribute.RegisteredInterfaces.Count() + 1 ];
-								interfaceTypes[ 0 ] = type;
-								registrationAttribute.RegisteredInterfaces.CopyTo( interfaceTypes, 1 );
-							} else {
-								interfaceTypes = registrationAttribute.RegisteredInterfaces;
-							}
-						} else {
-							if ( !type.GetInterfaces().Contains( type ) ) {
-								interfaceTypes = new Type[ type.GetInterfaces().Count() + 1 ];
-								interfaceTypes[ 0 ] = type;
-								type.GetInterfaces().CopyTo( interfaceTypes, 1 );
-							} else {
-								interfaceTypes = type.GetInterfaces();
-							}
-						}
+                    if ( registrationAttributes.Any() && isEnvironmentCorrect ) {
+                        var injectInListAttributes = type.GetSingleCustomAttribute<InjectInListAttribute>();
 
-						var explicitOverriddenTypes = new HashSet<Type>( type.GetCustomAttribute<InjectionExplicitOverrideAttribute>().SelectMany( a => a.OverriddenTypes ) );
+                        var registrationAttribute = registrationAttributes.First();
+                        Type[] interfaceTypes;
+                        if ( registrationAttribute.RegisteredInterfaces.Length > 0 ) {
+                            if ( !registrationAttribute.RegisteredInterfaces.Contains( type ) ) {
+                                interfaceTypes = new Type[ registrationAttribute.RegisteredInterfaces.Count() + 1 ];
+                                interfaceTypes[ 0 ] = type;
+                                registrationAttribute.RegisteredInterfaces.CopyTo( interfaceTypes, 1 );
+                            } else {
+                                interfaceTypes = registrationAttribute.RegisteredInterfaces;
+                            }
+                        } else {
+                            if ( !type.GetInterfaces().Contains( type ) ) {
+                                interfaceTypes = new Type[ type.GetInterfaces().Count() + 1 ];
+                                interfaceTypes[ 0 ] = type;
+                                type.GetInterfaces().CopyTo( interfaceTypes, 1 );
+                            } else {
+                                interfaceTypes = type.GetInterfaces();
+                            }
+                        }
 
-						foreach ( var interfaceType in interfaceTypes ) {
-							CheckInterfaceType( interfaceType, type );
+                        var explicitOverriddenTypes = new HashSet<Type>( type.GetCustomAttribute<InjectionExplicitOverrideAttribute>().SelectMany( a => a.OverriddenTypes ) );
 
-							// Selects the type to which the interface is mapped currently
-							var registeredType = serviceCollection.FirstOrDefault( reg => reg.ServiceType == interfaceType )?.ImplementationType;
+                        foreach ( var interfaceType in interfaceTypes ) {
+                            CheckInterfaceType( interfaceType, type );
 
-							if ( registeredType != null && !type.IsSubclassOf( registeredType ) && !explicitOverriddenTypes.Contains( registeredType ) ) {
+                            // Selects the type to which the interface is mapped currently
+                            var registeredType = serviceCollection.FirstOrDefault( reg => reg.ServiceType == interfaceType )?.ImplementationType;
 
-								// Check whether this type was overridden explicitly
-								var isExplicitlyOverridden = registeredType.EvaluateCustomAttributePredicate<InjectionExplicitOverrideAttribute>( eoa => eoa.OverriddenTypes.Any( t => t.Equals( type ) ) );
+                            if ( registeredType != null && !type.IsSubclassOf( registeredType ) && !explicitOverriddenTypes.Contains( registeredType ) ) {
 
-								if ( registeredType != type && !registeredType.IsSubclassOf( type ) && !isExplicitlyOverridden ) {
-									// Only registrations of inherited types may be overwritten. An alternative branch to an already registered type may not be registered.
-									throw new InjectionRegistrationException( interfaceType, type, $"Reflected interface {interfaceType.FullName} of {type.FullName} can not be registered, since it is already registered to {registeredType.FullName}, which is not a superclass." );
-								}
-							} else {
-								var listInterfaceTypes = injectInListAttributes.FirstOrDefault()?.RegisteredInterfaces ?? new Type[] { };
+                                // Check whether this type was overridden explicitly
+                                var isExplicitlyOverridden = registeredType.EvaluateCustomAttributePredicate<InjectionExplicitOverrideAttribute>( eoa => eoa.OverriddenTypes.Any( t => t.Equals( type ) ) );
 
-								foreach ( var listInterfaceType in listInterfaceTypes )
-									CheckInterfaceType( listInterfaceType, type );
+                                if ( registeredType != type && !registeredType.IsSubclassOf( type ) && !isExplicitlyOverridden ) {
+                                    // Only registrations of inherited types may be overwritten. An alternative branch to an already registered type may not be registered.
+                                    throw new InjectionRegistrationException( interfaceType, type, $"Reflected interface {interfaceType.FullName} of {type.FullName} can not be registered, since it is already registered to {registeredType.FullName}, which is not a superclass." );
+                                }
+                            } else {
+                                var listInterfaceTypes = injectInListAttributes.FirstOrDefault()?.RegisteredInterfaces ?? new Type[] { };
 
-								switch ( registrationAttribute ) {
-									case InjectAsGlobalSingletonAttribute _:
-										serviceCollection.AddSingleton( interfaceType, type );
+                                //foreach ( var listInterfaceType in listInterfaceTypes )
+                                //	CheckInterfaceType( listInterfaceType, type );
 
-										foreach ( var listInterfaceType in listInterfaceTypes )
-											serviceCollection.AddSingleton( listInterfaceType, type );
-										break;
-									case InjectAsRequestSingletonAttribute _:
-										serviceCollection.AddScoped( interfaceType, type );
+                                switch ( registrationAttribute ) {
+                                    case InjectAsGlobalSingletonAttribute _:
+                                        serviceCollection.AddSingleton( interfaceType, type );
 
-										foreach ( var listInterfaceType in listInterfaceTypes )
-											serviceCollection.AddScoped( listInterfaceType, type );
-										break;
-									case InjectAsNewInstanceAttribute _:
-										serviceCollection.AddTransient( interfaceType, type );
+                                        //foreach ( var listInterfaceType in listInterfaceTypes )
+                                        //	serviceCollection.AddSingleton( listInterfaceType, type );
+                                        break;
+                                    case InjectAsRequestSingletonAttribute _:
+                                        serviceCollection.AddScoped( interfaceType, type );
 
-										foreach ( var listInterfaceType in listInterfaceTypes )
-											serviceCollection.AddTransient( listInterfaceType, type );
-										break;
-									default:
-										// An implementation of IInjcetionScopeAttribute was given, but is not supported.
-										throw new InjectionRegistrationException( interfaceType, type, $"Reflected interface {interfaceType.FullName} of {type.FullName} can not be registered, since InjectionRegistrationAttribute was invalid." );
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+                                        //foreach ( var listInterfaceType in listInterfaceTypes )
+                                        //	serviceCollection.AddScoped( listInterfaceType, type );
+                                        break;
+                                    case InjectAsNewInstanceAttribute _:
+                                        serviceCollection.AddTransient( interfaceType, type );
 
-		private void CheckInterfaceType( Type interfaceType, Type type ) {
-			// TODO check via name, namespace, assembly and generic type arguments (via interfaces) if the interface types is equal to the type
-			if ( !interfaceType.GetGenericArguments().Any() && !interfaceType.IsAssignableFrom( type ) ) {
-				// A class may only be registered for type is declares. There might be an interface declared in the attribute which does not fit to the class.
-				throw new InjectionRegistrationException( interfaceType, type, $"Type {interfaceType.FullName} of {type.FullName} can not be registered, since it does not implement this type." );
-			}
-		}
-	}
+                                        //foreach ( var listInterfaceType in listInterfaceTypes )
+                                        //	serviceCollection.AddTransient( listInterfaceType, type );
+                                        break;
+                                    default:
+                                        // An implementation of IInjcetionScopeAttribute was given, but is not supported.
+                                        throw new InjectionRegistrationException( interfaceType, type, $"Reflected interface {interfaceType.FullName} of {type.FullName} can not be registered, since InjectionRegistrationAttribute was invalid." );
+                                }
+                            }
+                        }
+
+                        if ( injectInListAttributes.Count == 1 ) {
+                            var injectInListAttribute = injectInListAttributes.First();
+
+                            var listInterfaceTypes = injectInListAttribute.RegisteredInterfaces;
+
+                            foreach ( var interfaceType in listInterfaceTypes ) {
+                                CheckInterfaceType( interfaceType, type );
+
+                                _listInjectionRegistrationManager.RegisterTypeForListInterfaceType( type, interfaceType, injectInListAttribute.RemoveSubtypesFromList );
+                                serviceCollection.AddSingleton<ListInjectionRegistrationManager>( _listInjectionRegistrationManager );
+
+
+                                var listInjectionType = typeof( IEnumerable<> ).MakeGenericType( interfaceType );
+                                var listInjectionProxyType = typeof( ListInjectionProxy<> ).MakeGenericType( interfaceType );
+                                //if ( !MainContainer.IsRegistered( listInjectionType ) ) {
+                                serviceCollection.AddTransient( listInjectionType, listInjectionProxyType );
+                                //}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private void CheckInterfaceType( Type interfaceType, Type type ) {
+            // TODO check via name, namespace, assembly and generic type arguments (via interfaces) if the interface types is equal to the type
+            if ( !interfaceType.GetGenericArguments().Any() && !interfaceType.IsAssignableFrom( type ) ) {
+                // A class may only be registered for type is declares. There might be an interface declared in the attribute which does not fit to the class.
+                throw new InjectionRegistrationException( interfaceType, type, $"Type {interfaceType.FullName} of {type.FullName} can not be registered, since it does not implement this type." );
+            }
+        }
+    }
 }

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/InjectionRegistrationController.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/InjectionRegistrationController.cs
@@ -118,7 +118,7 @@ namespace CapeCode.DependencyInjection.Core {
                             foreach ( var interfaceType in listInterfaceTypes ) {
                                 CheckInterfaceType( interfaceType, type );
 
-                                _listInjectionRegistrationManager.RegisterTypeForListInterfaceType( type, interfaceType, injectInListAttribute.RemoveSubtypesFromList );
+                                _listInjectionRegistrationManager.RegisterTypeForListInterfaceType( type, interfaceType );
                                 serviceCollection.AddSingleton<ListInjectionRegistrationManager>( _listInjectionRegistrationManager );
 
 

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/ListInjectionProxy.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/ListInjectionProxy.cs
@@ -1,0 +1,40 @@
+﻿
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CapeCode.DependencyInjection.Core {
+    public class ListInjectionProxy<T> : IEnumerable<T> {
+
+        private readonly IEnumerable<T> _instances = new HashSet<T>();
+
+        public ListInjectionProxy( IServiceProvider serviceProvider ) {
+            var listInjectionRegistrationManager = serviceProvider.GetService<ListInjectionRegistrationManager>();
+            var types = listInjectionRegistrationManager.GetRegisteredTypesForListInterfaceType( typeof( T ) );
+            var typeInstances = new HashSet<T>();
+            if ( types != null ) {
+                foreach ( var type in types ) {
+                    typeInstances.Add( ( T ) serviceProvider.GetService( type ) );
+                }
+            }
+            _instances = typeInstances;
+        }
+
+        #region IEnumerable<T> Member
+
+        public IEnumerator<T> GetEnumerator() {
+            return _instances.GetEnumerator();
+        }
+
+        #endregion
+
+        #region IEnumerable Member
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return _instances.GetEnumerator();
+        }
+
+        #endregion
+    }
+}

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/ListInjectionRegistrationManager.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/ListInjectionRegistrationManager.cs
@@ -17,19 +17,19 @@ namespace CapeCode.DependencyInjection.Core {
             }
         }
 
-        public void RegisterTypeForListInterfaceType( Type registeredType, Type listInterfaceType, bool removeSubtypesFromList = false ) {
+        public void RegisterTypeForListInterfaceType( Type registeredType, Type listInterfaceType ) {
             if ( listInterfaceType != null ) {
                 if ( !_registeredTypesByListInterfaceType.ContainsKey( listInterfaceType ) ) {
                     _registeredTypesByListInterfaceType[ listInterfaceType ] = new HashSet<Type>();
                 }
                 if ( !_registeredTypesByListInterfaceType[ listInterfaceType ].Contains( registeredType ) ) {
-                    _registeredTypesByListInterfaceType[ listInterfaceType ].Add( registeredType );
+                    if ( !_registeredTypesByListInterfaceType[ listInterfaceType ].Any( t => t.IsSubclassOf( registeredType ) ) ) {
+                        _registeredTypesByListInterfaceType[ listInterfaceType ].Add( registeredType );
+                    }
                 }
-                if ( removeSubtypesFromList ) {
-                    foreach ( var oldRegistration in _registeredTypesByListInterfaceType[ listInterfaceType ].ToList() ) {
-                        if ( registeredType.IsSubclassOf( oldRegistration ) ) {
-                            _registeredTypesByListInterfaceType[ listInterfaceType ].Remove( oldRegistration );
-                        }
+                foreach ( var oldRegistration in _registeredTypesByListInterfaceType[ listInterfaceType ].ToList() ) {
+                    if ( registeredType.IsSubclassOf( oldRegistration ) ) {
+                        _registeredTypesByListInterfaceType[ listInterfaceType ].Remove( oldRegistration );
                     }
                 }
             }

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/ListInjectionRegistrationManager.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/ListInjectionRegistrationManager.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using CapeCode.DependencyInjection.Interfaces;
 
-namespace CapeCode.DependencyInjection {
+namespace CapeCode.DependencyInjection.Core {
     [InjectAsGlobalSingleton]
     class ListInjectionRegistrationManager {
 

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Interfaces/InjectInListAttribute.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Interfaces/InjectInListAttribute.cs
@@ -3,15 +3,9 @@
 namespace CapeCode.DependencyInjection.Interfaces {
     [System.AttributeUsage( System.AttributeTargets.Class, AllowMultiple = false, Inherited = false )]
     public class InjectInListAttribute : Attribute {
-
-        public bool RemoveSubtypesFromList { get; private set; }
+        
         public Type[] RegisteredInterfaces { get; private set; }
-
-        public InjectInListAttribute( bool removeSubtypesFromList, params Type[] registeredInterfaces ) {
-            RemoveSubtypesFromList = removeSubtypesFromList;
-            this.RegisteredInterfaces = registeredInterfaces;
-        }
-
+        
         public InjectInListAttribute( params Type[] registeredInterfaces ) {
             this.RegisteredInterfaces = registeredInterfaces;
         }

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Interfaces/InjectInListAttribute.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Interfaces/InjectInListAttribute.cs
@@ -4,7 +4,13 @@ namespace CapeCode.DependencyInjection.Interfaces {
     [System.AttributeUsage( System.AttributeTargets.Class, AllowMultiple = false, Inherited = false )]
     public class InjectInListAttribute : Attribute {
 
+        public bool RemoveSubtypesFromList { get; private set; }
         public Type[] RegisteredInterfaces { get; private set; }
+
+        public InjectInListAttribute( bool removeSubtypesFromList, params Type[] registeredInterfaces ) {
+            RemoveSubtypesFromList = removeSubtypesFromList;
+            this.RegisteredInterfaces = registeredInterfaces;
+        }
 
         public InjectInListAttribute( params Type[] registeredInterfaces ) {
             this.RegisteredInterfaces = registeredInterfaces;

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection/InjectionRegistrationController.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection/InjectionRegistrationController.cs
@@ -265,7 +265,7 @@ namespace CapeCode.DependencyInjection {
                                 }
 
                                 var listInjectionRegistrationManager = MainContainer.Resolve<ListInjectionRegistrationManager>();
-                                listInjectionRegistrationManager.RegisterTypeForListInterfaceType( type, interfaceType, injectInListAttribute.RemoveSubtypesFromList );
+                                listInjectionRegistrationManager.RegisterTypeForListInterfaceType( type, interfaceType );
 
                                 var listInjectionType = typeof( IEnumerable<> ).MakeGenericType( interfaceType );
                                 var listInjectionProxyType = typeof( ListInjectionProxy<> ).MakeGenericType( interfaceType );

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection/InjectionRegistrationController.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection/InjectionRegistrationController.cs
@@ -30,7 +30,7 @@ namespace CapeCode.DependencyInjection {
         private readonly IDictionary<Type, IList<Type>> _registrationsForDataContracts = new Dictionary<Type, IList<Type>>();
 
         private readonly IAssembliesCache _assembliesCache = new AssembliesCache();
-        
+
         private readonly IList<object> _enumRestrictions;
 
         // Manages the registration for Interfaces that inject a singelton depending on a given scope object.
@@ -101,7 +101,7 @@ namespace CapeCode.DependencyInjection {
         }
 
         public void RegisterTypes( IList<Type> types ) {
-            foreach ( Type type in types ) {
+            foreach ( var type in types ) {
                 RegisterType( type );
             }
         }
@@ -112,7 +112,7 @@ namespace CapeCode.DependencyInjection {
                     bool isEnvironmentCorrect = true;
                     IList<InjectionEnumRestrictionAttribute> enumRestrictionAttributes = type.GetCustomAttributes( false ).Where( attr => attr.GetType().IsSubclassOf( typeof( InjectionEnumRestrictionAttribute ) ) ).Cast<InjectionEnumRestrictionAttribute>().ToList<InjectionEnumRestrictionAttribute>();
                     // Filter attributes to have only attributes for arbitrary environments and attributes fitting to the current environment.
-                    if( enumRestrictionAttributes.Any() ) {
+                    if ( enumRestrictionAttributes.Any() ) {
                         isEnvironmentCorrect = enumRestrictionAttributes.All( era => era.ValidEnumValues.Any( vev => _enumRestrictions.Any( ev => Equals( ev, vev ) ) ) );
                     }
 
@@ -163,7 +163,7 @@ namespace CapeCode.DependencyInjection {
                             }
                         }
 
-                        foreach ( Type interfaceType in interfaceTypes ) {
+                        foreach ( var interfaceType in interfaceTypes ) {
                             // TODO check via name, namespace, assembly and generic type arguments (via interfaces) if the interface types is equal to the type
                             if ( !interfaceType.GetGenericArguments().Any() && !interfaceType.IsAssignableFrom( type ) ) {
                                 // A class may only be registered for type is declares. There might be an interface declared in the attribute which does not fit to the class.
@@ -174,14 +174,14 @@ namespace CapeCode.DependencyInjection {
                             if ( interfaceType.IsInterface && interfaceType.IsDefined( typeof( ServiceContractAttribute ), false ) ) {
                                 if ( !ServiceContracts.Contains( interfaceType ) ) {
                                     bool serviceAlreadyRegistered = false;
-                                    foreach ( Type serviceContract in ServiceContracts ) {
+                                    foreach ( var serviceContract in ServiceContracts ) {
                                         if ( interfaceType.IsAssignableFrom( serviceContract ) ) {
                                             serviceAlreadyRegistered = true;
                                             break;
                                         }
                                     }
                                     if ( !serviceAlreadyRegistered ) {
-                                        foreach ( Type serviceContract in ServiceContracts.ToList() ) {
+                                        foreach ( var serviceContract in ServiceContracts.ToList() ) {
                                             if ( serviceContract.IsAssignableFrom( interfaceType ) ) {
                                                 ServiceContracts.Remove( serviceContract );
                                             }
@@ -192,13 +192,13 @@ namespace CapeCode.DependencyInjection {
                             }
 
                             // Selects the type to which the interface is mapped currently
-                            Type registeredType = MainContainer.Registrations.ToList().Where( reg => reg.RegisteredType == interfaceType ).Select( reg => reg.MappedToType ).FirstOrDefault();
+                            var registeredType = MainContainer.Registrations.ToList().Where( reg => reg.RegisteredType == interfaceType ).Select( reg => reg.MappedToType ).FirstOrDefault();
 
                             Type registeredForType = null;
 
                             // Search all scoped registration for a mapping.
-                            foreach ( Type scopeType in this._registrationsForInterfacesForScopeTypes.Keys ) {
-                                IDictionary<Type, InstanceDependendScopeRegistration> scopingedRegistration = this._registrationsForInterfacesForScopeTypes[ scopeType ];
+                            foreach ( var scopeType in this._registrationsForInterfacesForScopeTypes.Keys ) {
+                                var scopingedRegistration = this._registrationsForInterfacesForScopeTypes[ scopeType ];
                                 if ( scopingedRegistration.ContainsKey( interfaceType ) ) {
                                     if ( registeredType == null ) {
                                         registeredType = scopingedRegistration[ interfaceType ].RegisteredToClass;
@@ -257,7 +257,7 @@ namespace CapeCode.DependencyInjection {
 
                             var listInterfaceTypes = injectInListAttribute.RegisteredInterfaces;
 
-                            foreach ( Type interfaceType in listInterfaceTypes ) {
+                            foreach ( var interfaceType in listInterfaceTypes ) {
                                 // TODO check via name, namespace, assembly and generic type arguments (via interfaces) if the interface types is equal to the type
                                 if ( !interfaceType.GetGenericArguments().Any() && !interfaceType.IsAssignableFrom( type ) ) {
                                     // A class may only be registered for type is declares. There might be an interface declared in the attribute which does not fit to the class.
@@ -265,11 +265,10 @@ namespace CapeCode.DependencyInjection {
                                 }
 
                                 var listInjectionRegistrationManager = MainContainer.Resolve<ListInjectionRegistrationManager>();
-                                listInjectionRegistrationManager.RegisterTypeForListInterfaceType( type, interfaceType );
+                                listInjectionRegistrationManager.RegisterTypeForListInterfaceType( type, interfaceType, injectInListAttribute.RemoveSubtypesFromList );
 
-
-                                Type listInjectionType = typeof( IEnumerable<> ).MakeGenericType( interfaceType );
-                                Type listInjectionProxyType = typeof( ListInjectionProxy<> ).MakeGenericType( interfaceType );
+                                var listInjectionType = typeof( IEnumerable<> ).MakeGenericType( interfaceType );
+                                var listInjectionProxyType = typeof( ListInjectionProxy<> ).MakeGenericType( interfaceType );
                                 if ( !MainContainer.IsRegistered( listInjectionType ) ) {
                                     MainContainer.RegisterType( listInjectionType, listInjectionProxyType, new PerResolveLifetimeManager() );
                                 }
@@ -312,7 +311,7 @@ namespace CapeCode.DependencyInjection {
                 interfaceTypes.Add( inheritedType );
             }
 
-            foreach ( Type interfaceType in interfaceTypes ) {
+            foreach ( var interfaceType in interfaceTypes ) {
                 // TODO check via name, namespace, assembly and generic type arguments (via interfaces) if the interface types is equal to the type
                 if ( !type.ContainsGenericParameters ) {
 
@@ -352,7 +351,7 @@ namespace CapeCode.DependencyInjection {
                 }
 #if DEBUG
                 var containerRegistrations = container.Registrations;
-                
+
                 var registrationsByNameAndType = containerRegistrations.Where( r => r.Name == null ).ToDictionaryDictionary( k => k.RegisteredType, k => k.Name, v => v.RegisteredType );
                 var registrationsByType = containerRegistrations.Where( r => r.Name == null ).ToDictionary( k => k.RegisteredType, v => v.RegisteredType );
 #endif

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection/ListInjectionRegistrationManager.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection/ListInjectionRegistrationManager.cs
@@ -17,19 +17,19 @@ namespace CapeCode.DependencyInjection {
             }
         }
 
-        public void RegisterTypeForListInterfaceType( Type registeredType, Type listInterfaceType, bool removeSubtypesFromList = false ) {
+        public void RegisterTypeForListInterfaceType( Type registeredType, Type listInterfaceType ) {
             if ( listInterfaceType != null ) {
                 if ( !_registeredTypesByListInterfaceType.ContainsKey( listInterfaceType ) ) {
                     _registeredTypesByListInterfaceType[ listInterfaceType ] = new HashSet<Type>();
                 }
                 if ( !_registeredTypesByListInterfaceType[ listInterfaceType ].Contains( registeredType ) ) {
-                    _registeredTypesByListInterfaceType[ listInterfaceType ].Add( registeredType );
+                    if ( !_registeredTypesByListInterfaceType[ listInterfaceType ].Any( t => t.IsSubclassOf( registeredType ) ) ) {
+                        _registeredTypesByListInterfaceType[ listInterfaceType ].Add( registeredType );
+                    }
                 }
-                if ( removeSubtypesFromList ) {
-                    foreach ( var oldRegistration in _registeredTypesByListInterfaceType[ listInterfaceType ].ToList() ) {
-                        if ( registeredType.IsSubclassOf( oldRegistration ) ) {
-                            _registeredTypesByListInterfaceType[ listInterfaceType ].Remove( oldRegistration );
-                        }
+                foreach ( var oldRegistration in _registeredTypesByListInterfaceType[ listInterfaceType ].ToList() ) {
+                    if ( registeredType.IsSubclassOf( oldRegistration ) ) {
+                        _registeredTypesByListInterfaceType[ listInterfaceType ].Remove( oldRegistration );
                     }
                 }
             }


### PR DESCRIPTION
List injection now handles list registrations seperately from other registrations to prevent unwanted inclusions in lists.
Registered subtypes now override the occurrence of their inherited types in lists.