### PR TITLE
Dependency injection now uses one lifetime per injection attribtue

### DIFF
--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/InjectionRegistrationController.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Core/InjectionRegistrationController.cs
@@ -16,6 +16,7 @@ namespace CapeCode.DependencyInjection.Core {
         private readonly IList<object> _enumRestrictions;
 
         private ListInjectionRegistrationManager _listInjectionRegistrationManager = new ListInjectionRegistrationManager();
+        private IList<DependencyInjectionRegistration> _registrations = new List<DependencyInjectionRegistration>();
 
         public void RegisterAllClasses( IServiceCollection serviceCollection, Assembly assembly ) {
             IList<Type> types;
@@ -36,97 +37,134 @@ namespace CapeCode.DependencyInjection.Core {
                     // Filter attributes to have only attributes for arbitrary environments and attributes fitting to the current environment.
                     var isEnvironmentCorrect = type.EvaluateDerivedCustomAttributePredicate<InjectionEnumRestrictionAttribute>( era => era.ValidEnumValues.Any( vev => _enumRestrictions.Any( ev => Equals( ev, vev ) ) ), trueIfEmpty: true );
 
-                    var registrationAttributes = type.GetSingleCustomDerivedAttribute<InjectionRegistrationAttribute>();
+                    var registrationAttributes = type.GetCustomDerivedAttribute<InjectionRegistrationAttribute>()
+                        .OrderByDescending( i => i.RegisteredInterfaces.Count() )
+                        .ToList();
 
                     if ( registrationAttributes.Any() && isEnvironmentCorrect ) {
                         var injectInListAttributes = type.GetSingleCustomAttribute<InjectInListAttribute>();
+                        var alreadyRegisteredTypes = new HashSet<Type>();
 
-                        var registrationAttribute = registrationAttributes.First();
-                        Type[] interfaceTypes;
-                        if ( registrationAttribute.RegisteredInterfaces.Length > 0 ) {
-                            if ( !registrationAttribute.RegisteredInterfaces.Contains( type ) ) {
-                                interfaceTypes = new Type[ registrationAttribute.RegisteredInterfaces.Count() + 1 ];
-                                interfaceTypes[ 0 ] = type;
-                                registrationAttribute.RegisteredInterfaces.CopyTo( interfaceTypes, 1 );
-                            } else {
-                                interfaceTypes = registrationAttribute.RegisteredInterfaces;
-                            }
-                        } else {
-                            if ( !type.GetInterfaces().Contains( type ) ) {
-                                interfaceTypes = new Type[ type.GetInterfaces().Count() + 1 ];
-                                interfaceTypes[ 0 ] = type;
-                                type.GetInterfaces().CopyTo( interfaceTypes, 1 );
-                            } else {
-                                interfaceTypes = type.GetInterfaces();
-                            }
-                        }
+                        foreach ( var registrationAttribute in registrationAttributes ) {
 
-                        var explicitOverriddenTypes = new HashSet<Type>( type.GetCustomAttribute<InjectionExplicitOverrideAttribute>().SelectMany( a => a.OverriddenTypes ) );
-
-                        foreach ( var interfaceType in interfaceTypes ) {
-                            CheckInterfaceType( interfaceType, type );
-
-                            // Selects the type to which the interface is mapped currently
-                            var registeredType = serviceCollection.FirstOrDefault( reg => reg.ServiceType == interfaceType )?.ImplementationType;
-
-                            if ( registeredType != null && !type.IsSubclassOf( registeredType ) && !explicitOverriddenTypes.Contains( registeredType ) ) {
-
-                                // Check whether this type was overridden explicitly
-                                var isExplicitlyOverridden = registeredType.EvaluateCustomAttributePredicate<InjectionExplicitOverrideAttribute>( eoa => eoa.OverriddenTypes.Any( t => t.Equals( type ) ) );
-
-                                if ( registeredType != type && !registeredType.IsSubclassOf( type ) && !isExplicitlyOverridden ) {
-                                    // Only registrations of inherited types may be overwritten. An alternative branch to an already registered type may not be registered.
-                                    throw new InjectionRegistrationException( interfaceType, type, $"Reflected interface {interfaceType.FullName} of {type.FullName} can not be registered, since it is already registered to {registeredType.FullName}, which is not a superclass." );
+                            IList<Type> interfaceTypes = registrationAttribute.RegisteredInterfaces;
+                            if ( interfaceTypes.Any() ) {
+                                var repeatedlyRegisteredTypes = interfaceTypes.Where( i => alreadyRegisteredTypes.Contains( i ) ).ToList();
+                                if ( repeatedlyRegisteredTypes.Any() ) {
+                                    throw new InjectionRegistrationException( repeatedlyRegisteredTypes.First(), type, $"Reflected interfaces [{string.Join( ", ", repeatedlyRegisteredTypes.Select( i => i.FullName ) )}] of {type.FullName} cannot be registered, since they were already registered for the same type with another attribute." );
                                 }
+                                //    if ( !registrationAttribute.RegisteredInterfaces.Contains( type ) ) {
+                                //        interfaceTypes = new Type[ registrationAttribute.RegisteredInterfaces.Count() + 1 ];
+                                //        interfaceTypes[ 0 ] = type;
+                                //        registrationAttribute.RegisteredInterfaces.CopyTo( interfaceTypes, 1 );
+                                //    } else {
+                                //        interfaceTypes = registrationAttribute.RegisteredInterfaces;
+                                //    }
                             } else {
-                                var listInterfaceTypes = injectInListAttributes.FirstOrDefault()?.RegisteredInterfaces ?? new Type[] { };
-
-                                //foreach ( var listInterfaceType in listInterfaceTypes )
-                                //	CheckInterfaceType( listInterfaceType, type );
-
-                                switch ( registrationAttribute ) {
-                                    case InjectAsGlobalSingletonAttribute _:
-                                        serviceCollection.AddSingleton( interfaceType, type );
-
-                                        //foreach ( var listInterfaceType in listInterfaceTypes )
-                                        //	serviceCollection.AddSingleton( listInterfaceType, type );
-                                        break;
-                                    case InjectAsRequestSingletonAttribute _:
-                                        serviceCollection.AddScoped( interfaceType, type );
-
-                                        //foreach ( var listInterfaceType in listInterfaceTypes )
-                                        //	serviceCollection.AddScoped( listInterfaceType, type );
-                                        break;
-                                    case InjectAsNewInstanceAttribute _:
-                                        serviceCollection.AddTransient( interfaceType, type );
-
-                                        //foreach ( var listInterfaceType in listInterfaceTypes )
-                                        //	serviceCollection.AddTransient( listInterfaceType, type );
-                                        break;
-                                    default:
-                                        // An implementation of IInjcetionScopeAttribute was given, but is not supported.
-                                        throw new InjectionRegistrationException( interfaceType, type, $"Reflected interface {interfaceType.FullName} of {type.FullName} can not be registered, since InjectionRegistrationAttribute was invalid." );
+                                interfaceTypes = type.GetInterfaces().Where( i => !alreadyRegisteredTypes.Contains( i ) ).ToList();
+                                if ( !interfaceTypes.Contains( type ) ) {
+                                    interfaceTypes.Insert( 0, type );
                                 }
+                                interfaceTypes = interfaceTypes.Where( i => !alreadyRegisteredTypes.Contains( i ) ).ToList();
                             }
-                        }
 
-                        if ( injectInListAttributes.Count == 1 ) {
-                            var injectInListAttribute = injectInListAttributes.First();
+                            var explicitOverriddenTypes = new HashSet<Type>( type.GetCustomAttribute<InjectionExplicitOverrideAttribute>().SelectMany( a => a.OverriddenTypes ) );
+                            DependencyInjectionRegistration firstRegistration = null;
 
-                            var listInterfaceTypes = injectInListAttribute.RegisteredInterfaces;
-
-                            foreach ( var interfaceType in listInterfaceTypes ) {
+                            foreach ( var interfaceType in interfaceTypes ) {
                                 CheckInterfaceType( interfaceType, type );
 
-                                _listInjectionRegistrationManager.RegisterTypeForListInterfaceType( type, interfaceType );
-                                serviceCollection.AddSingleton<ListInjectionRegistrationManager>( _listInjectionRegistrationManager );
+                                // Selects the type to which the interface is mapped currently
+                                var existingRegistration = _registrations.SingleOrDefault( i => i.RegisteredInterface == interfaceType );
+                                if ( existingRegistration != null && !type.IsSubclassOf( existingRegistration.RegisteredToType ) && !explicitOverriddenTypes.Contains( existingRegistration.RegisteredToType ) ) {
+                                    // Check whether this type was overridden explicitly
+                                    var isExplicitlyOverridden = existingRegistration.RegisteredToType.EvaluateCustomAttributePredicate<InjectionExplicitOverrideAttribute>( eoa => eoa.OverriddenTypes.Any( t => t.Equals( type ) ) );
 
+                                    if ( existingRegistration.RegisteredToType != type && !existingRegistration.RegisteredToType.IsSubclassOf( type ) && !isExplicitlyOverridden ) {
+                                        // Only registrations of inherited types may be overwritten. An alternative branch to an already registered type may not be registered.
+                                        throw new InjectionRegistrationException( interfaceType, type, $"Reflected interface {interfaceType.FullName} of {type.FullName} cannot be registered, since it is already registered to {existingRegistration.RegisteredToType.FullName}, which is not a superclass." );
+                                    }
+                                    if ( firstRegistration == null ) {
+                                        firstRegistration = existingRegistration;
+                                    }
+                                } else {
+                                    var registration = new DependencyInjectionRegistration {
+                                        RegisteredInterface = interfaceType,
+                                        RegisteredToType = type,
+                                        UsedOtherRegistration = firstRegistration
+                                    };
+                                    _registrations.Add( registration );
 
-                                var listInjectionType = typeof( IEnumerable<> ).MakeGenericType( interfaceType );
-                                var listInjectionProxyType = typeof( ListInjectionProxy<> ).MakeGenericType( interfaceType );
-                                //if ( !MainContainer.IsRegistered( listInjectionType ) ) {
-                                serviceCollection.AddTransient( listInjectionType, listInjectionProxyType );
-                                //}
+                                    switch ( registrationAttribute ) {
+                                        case InjectAsGlobalSingletonAttribute _:
+                                            registration.Lifetime = ServiceLifetime.Singleton;
+                                            if ( firstRegistration == null ) {
+                                                serviceCollection.AddSingleton( interfaceType, type );
+                                            } else {
+                                                serviceCollection.AddSingleton( interfaceType, sp => sp.GetService( firstRegistration.RegisteredInterface ) );
+                                            }
+                                            break;
+                                        case InjectAsRequestSingletonAttribute _:
+                                            registration.Lifetime = ServiceLifetime.Scoped;
+                                            if ( firstRegistration == null ) {
+                                                serviceCollection.AddScoped( interfaceType, type );
+                                            } else {
+                                                serviceCollection.AddScoped( interfaceType, sp => sp.GetService( firstRegistration.RegisteredInterface ) );
+                                            }
+                                            break;
+                                        case InjectAsNewInstanceAttribute _:
+                                            registration.Lifetime = ServiceLifetime.Transient;
+                                            if ( firstRegistration == null ) {
+                                                serviceCollection.AddTransient( interfaceType, type );
+                                            } else {
+                                                serviceCollection.AddTransient( interfaceType, sp => sp.GetService( firstRegistration.RegisteredInterface ) );
+                                            }
+                                            break;
+                                        default:
+                                            // An implementation of IInjcetionScopeAttribute was given, but is not supported.
+                                            throw new InjectionRegistrationException( interfaceType, type, $"Reflected interface {interfaceType.FullName} of {type.FullName} cannot be registered, since InjectionRegistrationAttribute was invalid." );
+                                    }
+
+                                    if ( existingRegistration != null && ( type.IsSubclassOf( existingRegistration.RegisteredToType ) || explicitOverriddenTypes.Contains( existingRegistration.RegisteredToType ) ) ) {
+                                        var existingRegistrationChildren = existingRegistration.UsedByOtherRegistrations.ToList();
+                                        foreach ( var existingRegistrationChild in existingRegistrationChildren ) {
+                                            CheckInterfaceType( existingRegistrationChild.RegisteredInterface, type );
+
+                                            existingRegistrationChild.RegisteredToType = type;
+                                            existingRegistrationChild.UsedOtherRegistration = registration;
+                                            registration.UsedByOtherRegistrations.Add( existingRegistrationChild );
+                                        }
+                                        _registrations.Remove( existingRegistration );
+                                    }
+
+                                    if ( firstRegistration == null ) {
+                                        firstRegistration = registration;
+                                    } else {
+                                        firstRegistration.UsedByOtherRegistrations.Add( registration );
+                                    }
+                                }
+                            }
+
+                            if ( injectInListAttributes.Count == 1 ) {
+                                var injectInListAttribute = injectInListAttributes.First();
+
+                                var listInterfaceTypes = injectInListAttribute.RegisteredInterfaces;
+
+                                if ( !serviceCollection.Any( reg => reg.ServiceType == typeof( ListInjectionRegistrationManager ) ) ) {
+                                    serviceCollection.AddSingleton( _listInjectionRegistrationManager );
+                                }
+
+                                foreach ( var interfaceType in listInterfaceTypes ) {
+                                    CheckInterfaceType( interfaceType, type );
+
+                                    _listInjectionRegistrationManager.RegisterTypeForListInterfaceType( type, interfaceType );
+
+                                    var listInjectionType = typeof( IEnumerable<> ).MakeGenericType( interfaceType );
+                                    if ( !serviceCollection.Any( reg => reg.ServiceType == listInjectionType ) ) {
+                                        var listInjectionProxyType = typeof( ListInjectionProxy<> ).MakeGenericType( interfaceType );
+                                        serviceCollection.AddTransient( listInjectionType, listInjectionProxyType );
+                                    }
+                                }
                             }
                         }
                     }
@@ -140,6 +178,15 @@ namespace CapeCode.DependencyInjection.Core {
                 // A class may only be registered for type is declares. There might be an interface declared in the attribute which does not fit to the class.
                 throw new InjectionRegistrationException( interfaceType, type, $"Type {interfaceType.FullName} of {type.FullName} can not be registered, since it does not implement this type." );
             }
+        }
+
+        private class DependencyInjectionRegistration {
+            public Type RegisteredInterface { get; set; }
+            public Type RegisteredToType { get; set; }
+            public ServiceLifetime Lifetime { get; set; }
+            public DependencyInjectionRegistration UsedOtherRegistration { get; set; }
+            public IList<DependencyInjectionRegistration> UsedByOtherRegistrations { get; private set; } = new List<DependencyInjectionRegistration>();
+
         }
     }
 }

--- a/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Interfaces/InjectionRegistrationAttribute.cs
+++ b/CapeCode.DependencyInjection/CapeCode.DependencyInjection.Interfaces/InjectionRegistrationAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 namespace CapeCode.DependencyInjection.Interfaces {
-    [System.AttributeUsage( System.AttributeTargets.Class, AllowMultiple = false, Inherited = false )]
+    [System.AttributeUsage( System.AttributeTargets.Class, AllowMultiple = true, Inherited = false )]
     public abstract class InjectionRegistrationAttribute : Attribute {
         public Type[] RegisteredInterfaces { get; private set; }
 


### PR DESCRIPTION
Dependency injection uses the same lifetime instance for multiple implemented interfaces.
Allowing multiple InjectionRegistrationAttributes to make an implementation be used for different interfaces with different lifetimes.